### PR TITLE
Fix Retrier's begin completion call

### DIFF
--- a/Sources/RetryKit/Retrier.swift
+++ b/Sources/RetryKit/Retrier.swift
@@ -61,6 +61,7 @@ public struct Retrier {
             task.work { [self] output in
                 // validate whether output is acceptable, otherwise attempt retry
                 guard task.outputValidation(output) else {
+                    completion?()
                     return
                 }
 

--- a/Tests/RetryKitTests/RetrierTests.swift
+++ b/Tests/RetryKitTests/RetrierTests.swift
@@ -48,6 +48,20 @@ final class RetrierTests: XCTestCase {
             XCTAssertEqual(count, 1)
         }
     }
+    
+    func testCallsCompletionClosure() {
+        let task = Task<Void>(maximumAttempts: 2, work: {
+            $0(())
+        }, outputValidation: { false })
+        let retrier = Retrier(dispatchQueue: .main)
+        
+        let expectation = XCTestExpectation(description: "Should call completion closure when succeeds")
+        retrier.begin(task) {
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 1.0)
+    }
 
     // MARK: - Strategies
     func testDelayForImmediateStrategy() {


### PR DESCRIPTION
Hi! Congratulations on this project!
It's really helpful in sooo many cases.

I did some tests here and I found a little bug: when you start a task that succeeds on the first try, the completion closure will never be called. But it's simple to solve this.